### PR TITLE
Add missing param

### DIFF
--- a/neo-cli/centos/Dockerfile
+++ b/neo-cli/centos/Dockerfile
@@ -14,7 +14,7 @@ ENV NEOCLI_RELEASE neo-cli-centos.7-x64.zip
 ENV NEOCLI_DOWNLOAD_URL https://github.com/neo-project/neo-cli/releases/download/v$NEOCLI_VERSION/$NEOCLI_RELEASE
 
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 \
-    && yum update \
+    && yum update -y \
     && yum install -y --setopt=tsflags=nodocs unzip libunwind libicu epel-release \
     && rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 \
     && yum install -y --setopt=tsflags=nodocs leveldb-devel \


### PR DESCRIPTION
Added missing parameter to resolve following error when building the image:

```
Total download size: 12 M
Is this ok [y/d/N]: Exiting on user command
Your transaction was saved, rerun it with:
 yum load-transaction /tmp/yum_save_tx.2018-01-29.02-48.J3a5Qm.yumtx
The command '/bin/sh -c rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
&& yum update&& yum install -y --setopt=tsflags=nodocs unzip libunwind libicu epel-release
&& rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
&& yum install -y --setopt=tsflags=nodocs leveldb-devel
&& yum clean all' returned a non-zero code: 1
```